### PR TITLE
Dynamically find the Chrome executable instead of hardcoding the path.

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,13 +110,15 @@ How to run it
 1. everything looks fine, but scripts from webpack arent loading.
   - Probably problem with development ssl certificates. Open any script (i.e. https://localhost:3001/path_to_your_script.js) in separate tab and allow chrome to load it anyway. Then reload extension.
 
+#### Done
+- [x] detect Chrome path for building extension
+
 #### Future
 
 - [ ] allow to pass existing `.pem` when building extension
 - [ ] experiment with hot middleware (hints in NOTE.md)
 - [ ] allow to have "static" files which will be merged into build
 - [ ] allow to reload extension when popup html file changed
-- [ ] detect Chrome path for building extension
 - [ ] solve Hot reload fix better than overriding file in /node_modules. It is really ugly and hacky
 - [ ] test assets without base64
 - [ ] add support for [extension updating](https://developer.chrome.com/extensions/packaging#update)

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "babel-preset-stage-0": "6.5.0",
     "babel-preset-target": "0.0.4",
     "case-sensitive-paths-webpack-plugin": "1.1.4",
+    "chrome-location": "^1.2.1",
     "colors": "1.1.2",
     "commander": "2.9.0",
     "css-loader": "0.24.0",

--- a/src/build.js
+++ b/src/build.js
@@ -8,6 +8,7 @@ import { exec } from 'child_process'
 import fs from 'fs-extra'
 import color from 'colors/safe';
 import webpack from 'webpack'
+import chromeBinaryPath from 'chrome-location';
 
 // our
 import easyRequire from './utils/easyRequire'
@@ -92,8 +93,6 @@ function webpackProduction(webpackConfig) {
 function makeExtension(options) {
   return function() {
     return new Promise((resolve, reject) => {
-      // TODO detect system and Chrome path
-      const chromeBinaryPath = '/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome'
       console.log(color.yellow(`Building extension into '${options.release}'`))
 
       setTimeout(() => {


### PR DESCRIPTION
This resolves issue #3.

It's a rebased version of pull request #4 to fix a conflict with more recent commits. Additionally, there is now an update to the "Done/Future" section of the README to reflect the changes.
