### PR TITLE
Allow package property override from manifest

### DIFF
--- a/src/manifest/processor/package_json.js
+++ b/src/manifest/processor/package_json.js
@@ -11,10 +11,10 @@ export default function(manifest) {
   const { name, description, version } = packageConfig
 
   manifest = {
-    ...manifest,
     name,
     description,
-    version
+    version,
+    ...manifest
   }
 
   return {manifest}


### PR DESCRIPTION
Currently the name, description and version are automatically pulled from package.json exclusively and those same properties defined in manifest.json will be ignored.

While I cannot see a good reason why anyone would want to define the description or version in two different places, there is a good reason as of why you don't want to use your NPM package name as your Chrome extension name.

NPM package naming is strict while Chrome extension allows prettier display names, therefore it seems like a good idea to be able to define the Chrome extension name at the manifest level. For example the package `my-cool-extension` could now be displayed as `My Cool Extension for Chrome` in the Chrome store and extension manager.
